### PR TITLE
Add Task Provider for PSBuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"url": "https://github.com/NachoxMacho"
 	},
 	"engines": {
-		"vscode": "^1.65.0"
+		"vscode": "^1.65.2"
 	},
 	"repository": "https://github.com/NachoxMacho/PSBuild-Extension",
 	"categories": [
@@ -48,6 +48,20 @@
 				"language": "powershell",
 				"path": "./snippets/powershell.json"
 			}
+		],
+		"taskDefinitions": [
+			{
+				"type": "psbuild",
+				"required": [
+					"task"
+				],
+				"properties": {
+					"task": {
+						"type": "string",
+						"description": "The PSBuild Task to customize"
+					}
+				}
+			}
 		]
 	},
 	"scripts": {
@@ -63,7 +77,7 @@
 		"@types/glob": "^7.2.0",
 		"@types/mocha": "^9.1.0",
 		"@types/node": "14.x",
-		"@types/vscode": "^1.65.0",
+		"@types/vscode": "^1.65.2",
 		"@typescript-eslint/eslint-plugin": "^5.15.0",
 		"@typescript-eslint/parser": "^5.15.0",
 		"@vscode/test-electron": "^2.1.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,12 +25,14 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(disposable);
 
 	// Setup Task Provider
+
+	// Don't setup tasks if we aren't in a folder or workspace
 	const workspaceRoot = (vscode.workspace.workspaceFolders && (vscode.workspace.workspaceFolders.length > 0))
 		? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
 	if (!workspaceRoot) {
 		return;
 	}
-
+	// Register the tasks
 	psbuildTaskProvider = vscode.tasks.registerTaskProvider(PSBuildTaskProvider.PSBuildType, new PSBuildTaskProvider(workspaceRoot));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,15 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { PSBuildTaskProvider } from './psbuildTaskProvider';
+
+// Globals
+let psbuildTaskProvider: vscode.Disposable | undefined;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	
+
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "psbuild" is now active!');
@@ -18,9 +22,21 @@ export function activate(context: vscode.ExtensionContext) {
 		// Display a message box to the user
 		vscode.window.showInformationMessage('Hello World from PSBuild!');
 	});
-
 	context.subscriptions.push(disposable);
+
+	// Setup Task Provider
+	const workspaceRoot = (vscode.workspace.workspaceFolders && (vscode.workspace.workspaceFolders.length > 0))
+		? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
+	if (!workspaceRoot) {
+		return;
+	}
+
+	psbuildTaskProvider = vscode.tasks.registerTaskProvider(PSBuildTaskProvider.PSBuildType, new PSBuildTaskProvider(workspaceRoot));
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() {
+	if (psbuildTaskProvider) {
+		psbuildTaskProvider.dispose();
+	}
+}

--- a/src/psbuildTaskProvider.ts
+++ b/src/psbuildTaskProvider.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+export class PSBuildTaskProvider implements vscode.TaskProvider {
+    static PSBuildType = 'PSBuild';
+    private PSBuildPromise: Thenable<vscode.Task[]> | undefined = undefined;
+
+    constructor(workspaceRoot: string) {
+        const pattern = path.join(workspaceRoot, 'psconfig.psd1');
+        const fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+        fileWatcher.onDidChange(() => this.PSBuildPromise = undefined);
+        fileWatcher.onDidCreate(() => this.PSBuildPromise = undefined);
+        fileWatcher.onDidDelete(() => this.PSBuildPromise = undefined);
+    }
+
+    public provideTasks(): Thenable<vscode.Task[]> | undefined {
+        if (!this.PSBuildPromise) {
+            this.PSBuildPromise = getPSBuildTasks();
+        }
+        return this.PSBuildPromise;
+    }
+
+    public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+        const task = _task.definition.task;
+        // A PSBuild task consists of a task and an optional file as specified in PSBuildTaskDefinition
+        // Make sure that this looks like a PSBuild task by checking that there is a task.
+        if (task) {
+            // resolveTask requires that the same definition object be used.
+            const definition: PSBuildTaskDefinition = <any>_task.definition;
+            return new vscode.Task(definition, _task.scope ?? vscode.TaskScope.Workspace, definition.task, 'PSBuild', new vscode.ShellExecution(`Invoke-RSMBuild -Task ${definition.task}`),'$pester');
+        }
+        return undefined;
+    }
+}
+
+function exists(file: string): Promise<boolean> {
+    return new Promise<boolean>((resolve, _reject) => {
+        fs.exists(file, (value) => {
+            resolve(value);
+        });
+    });
+}
+
+interface PSBuildTaskDefinition extends vscode.TaskDefinition {
+    /**
+     * The task name
+     */
+    task: string;
+
+    /**
+     * The PSBuild file containing the task
+     */
+    file?: string;
+}
+
+const buildNames: string[] = ['build', 'clean'];
+function isBuildTask(name: string): boolean {
+    for (const buildName of buildNames) {
+        if (name.indexOf(buildName) !== -1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const testNames: string[] = ['test'];
+function isTestTask(name: string): boolean {
+    for (const testName of testNames) {
+        if (name.indexOf(testName) !== -1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+async function getPSBuildTasks(): Promise<vscode.Task[]> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    const result: vscode.Task[] = [];
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return result;
+    }
+    for (const workspaceFolder of workspaceFolders) {
+        const folderString = workspaceFolder.uri.fsPath;
+        if (!folderString) {
+            continue;
+        }
+        const PSBuildFile = path.join(folderString, 'psconfig.psd1');
+        if (!await exists(PSBuildFile)) {
+            continue;
+        }
+
+        let possibleTasks = [];
+        possibleTasks.push(...buildNames);
+        possibleTasks.push(...testNames);
+
+        for (const taskName of possibleTasks) {
+            const kind: PSBuildTaskDefinition = {
+                type: 'PSBuild',
+                task: taskName
+            };
+            const task = new vscode.Task(kind, workspaceFolder, taskName, 'PSBuild', new vscode.ShellExecution(`Invoke-RSMBuild -Task ${taskName}`),'$pester');
+            result.push(task);
+            if (isBuildTask(taskName)) {
+                task.group = vscode.TaskGroup.Build;
+            } else if (isTestTask(taskName)) {
+                task.group = vscode.TaskGroup.Test;
+            }
+        }
+    }
+    return result;
+}

--- a/src/psbuildTaskProvider.ts
+++ b/src/psbuildTaskProvider.ts
@@ -51,14 +51,9 @@ interface PSBuildTaskDefinition extends vscode.TaskDefinition {
      * The task name
      */
     task: string;
-
-    /**
-     * The PSBuild file containing the task
-     */
-    file?: string;
 }
 
-const buildNames: string[] = ['build', 'clean'];
+const buildNames: string[] = ['clean', 'build', 'ci', 'package'];
 function isBuildTask(name: string): boolean {
     for (const buildName of buildNames) {
         if (name.indexOf(buildName) !== -1) {
@@ -94,6 +89,7 @@ async function getPSBuildTasks(): Promise<vscode.Task[]> {
             continue;
         }
 
+        // Combine build and test tasks to just output possible tasks
         let possibleTasks = [];
         possibleTasks.push(...buildNames);
         possibleTasks.push(...testNames);


### PR DESCRIPTION
This adds the ability for vscode to auto-detect tasks when a `psconfig.psd1` exists in the directory. This is the first version of this and needs to be improved, but starting functionality is there